### PR TITLE
Fix multi-job build for pbbam

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -317,7 +317,7 @@ htslib:
 seqan:
 	$(MAKE) -j1 -C ports/pacbio/$@ do-install
 pbbam:
-	$(MAKE) -j1 -C ports/pacbio/$@ do-install
+	$(MAKE) -C ports/pacbio/$@ do-install
 pbccs:
 	$(MAKE) -j1 -C ports/pacbio/$@ do-install
 dazzdb:

--- a/ports/pacbio/pbbam/Makefile
+++ b/ports/pacbio/pbbam/Makefile
@@ -37,7 +37,7 @@ $(_WRKSRC)/build/Makefile:
 do-build:
 	$(MAKE) -C $(_WRKSRC)/build
 do-install: | $(PREFIX)/var/pkg/$(_NAME)
-$(PREFIX)/var/pkg/$(_NAME):
+$(PREFIX)/var/pkg/$(_NAME): | $(_WRKSRC)/build/Makefile
 	rm -rf $(STAGING)/$(_NAME)
 	mkdir -p $(STAGING)/$(_NAME)
 	cd $(_WRKSRC) && tar cf - bin lib include | tar xf - -C $(STAGING)/$(_NAME)


### PR DESCRIPTION
This is an example. Do not merge.

We need a better way. Multi-job between pkgs is somewhat helpful, but multi-job *within* a package can be a big speed-up.