### PR TITLE
set -o pipefail to catch errors

### DIFF
--- a/ports/thirdparty/swig/Makefile
+++ b/ports/thirdparty/swig/Makefile
@@ -19,7 +19,7 @@ pcre-8.38.tar.gz:
 do-config: | $(_WRKSRC)/config.log
 $(_WRKSRC)/config.log:
 	cp pcre-8.38.tar.gz $(_WRKSRC)/
-	(cd $(_WRKSRC) && \
+	set -o pipefail && (cd $(_WRKSRC) && \
         Tools/pcre-build.sh && \
         CFLAGS="$(CFLAGS)" \
         CC="$(CC) -L$(PREFIX)/lib" \


### PR DESCRIPTION
**ConsensusCore2** failed only because **swig** failed, but the **swig** failure did not stop the build. You might need this in other places too.

This is why you should not be writing little bash scripts within makefiles. Use separate files for rule-scripts. Then everything is clear. Don't be afraid of extra files. The filesystem is efficient. Let **make** do what **make** does best; let **bash** do what **bash** does best; etc.

    do-install:
        ${PFHOME}/bin/run-with-capture-and-activity.sh do-install.sh

Then, `run-with-capture-and-activity.sh` can set `pipefail`, capture to a sensibly named log-file, pipe through `activity`, etc.

I'm still working on why **swig** failed... Oh, pcre cannot be built with gcc-4.9.2. See [other issue](https://github.com/PacificBiosciences/pitchfork/pull/186#issuecomment-192680891).