### PR TITLE
Pip cache

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,8 +20,9 @@ addons:
       - cmake
 cache:
   directories:
-    - $HOME/.ccache
     - $HOME/distfiles
+#    - $HOME/.cache
+#    - $HOME/.ccache
 
 install:
   - bin/travisbuild.sh

--- a/mk/config.mk
+++ b/mk/config.mk
@@ -20,7 +20,7 @@ PFHOME    := $(realpath ../../..)
 WORKSPACE  ?= $(PFHOME)/workspace
 PREFIX     ?= $(PFHOME)/deployment
 STAGING    ?= $(PFHOME)/staging
-CCACHE_DIR ?= $(WORKSPACE)/.ccache
+CCACHE_DIR ?= $(HOME)/.ccache
 PIP         = $(PREFIX)/bin/pip --cache-dir ${PREFIX}.pip
 
 ifneq ($(origin DEBUG),undefined)

--- a/mk/config.mk
+++ b/mk/config.mk
@@ -21,7 +21,7 @@ WORKSPACE  ?= $(PFHOME)/workspace
 PREFIX     ?= $(PFHOME)/deployment
 STAGING    ?= $(PFHOME)/staging
 CCACHE_DIR ?= $(WORKSPACE)/.ccache
-PIP         = $(PREFIX)/bin/pip --no-cache-dir
+PIP         = $(PREFIX)/bin/pip --cache-dir ${PREFIX}.pip
 
 ifneq ($(origin DEBUG),undefined)
     DEBUG=1


### PR DESCRIPTION
Also, put ccache in $HOME, since ccache is very reliable, and since we already tell Travis to cache it. If Travis takes too much time to load the cache, we can change .travis.yml.