### PR TITLE
old samtools

### DIFF
--- a/bin/travistest.sh
+++ b/bin/travistest.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 . ${HOME}/local/setup-env.sh
-set -e
+set -ex
 
 bam2bax -h
 bamSieve -h

--- a/ports/thirdparty/samtools/Makefile
+++ b/ports/thirdparty/samtools/Makefile
@@ -1,16 +1,16 @@
 include ../../../mk/pitchfork.mk
 
 # Local variables
-_NAME   = samtools-1.3
-_URL    = https://github.com/samtools/samtools/releases/download/1.3
+_NAME   = samtools-0.1.20
+_URL    = https://github.com/samtools/samtools/archive
 _WRKSRC = $(WORKSPACE)/$(_NAME)
-_FILE   = $(_NAME).tar.bz2
+_FILE   = 0.1.20.tar.gz
 
 # Local works
 do-extract: $(_WRKSRC)
 $(_WRKSRC): | do-fetch
 	$(MD5SUM) -c MD5SUM || exit
-	tar jxf $(_FILE) -C $(WORKSPACE)
+	tar zxf $(_FILE) -C $(WORKSPACE)
 ifeq ($(OPSYS),Darwin)
 	cat patch-01 | (cd $(_WRKSRC) && patch -p0)
 	$(SED) -i -e 's/-rdynamic//g' $(_WRKSRC)/Makefile $(_WRKSRC)/htslib-*/configure*
@@ -18,7 +18,7 @@ endif
 do-fetch: $(_FILE)
 $(_FILE):
 	$(CURL) -L -O $(_URL)/$@
-do-config: $(_WRKSRC)/config.log
+old-do-config: $(_WRKSRC)/config.log
 $(_WRKSRC)/config.log: | do-extract
 	(cd $(_WRKSRC) && \
          CFLAGS="-I$(_WRKSRC)/htslib-1.3 $(CFLAGS)" ./configure --prefix=$(PREFIX) \


### PR DESCRIPTION
We want an internal variant of 0.1.19, but 0.1.20 might be close enough.

But now, I see this error when I build:
```
gcc -c -g -Wall -O2  -fPIC -I/lustre/hpcprod/cdunn/pf/include -fPIC -I/lustre/hpcprod/cdunn/pf/include -fPIC -I/lustre/hpcprod/cdunn/pf/include -D_FILE_OFFSET_BITS=64 -D_LARGEFILE64_SOURCE -D_USE_KNETFILE -D_CURSES_LIB=1 -I. bam_tview_curses.c -o bam_tview_curses.o
bam_tview_curses.c:5:20: fatal error: curses.h: No such file or directory
```
* https://github.com/samtools/samtools/blob/0.1.20/INSTALL

Internally, see
* `smrtanalysis/build/3.x/buildctl/thirdparty/samtools/samtools_fromsrc_0.1.19+pbi86.mobs.ish`
* `smrtanalysis/thirdparty.src/samtools/samtools_0.1.19+pbi86/legacy_2.x_files`