### PR TITLE
reuse the makefile from daligner

### DIFF
--- a/ports/pacbio/daligner/Makefile
+++ b/ports/pacbio/daligner/Makefile
@@ -5,9 +5,6 @@ _NAME             = daligner
 $(_NAME)_REPO    ?= git://github.com/PacificBiosciences/DALIGNER
 _WRKSRC           = $(WORKDIR)/$(_NAME)
 $(_NAME)_VERSION ?= HEAD
-PROGRAMS          = daligner    LAsplit    LAsort  LAmerge HPCmapper \
-                    HPCdaligner LAshow     LAcheck LAcat   LA4Falcon \
-                    DB2Falcon   daligner_p LA4Ice
 
 # Local works
 do-fetch: $(_WRKSRC)
@@ -28,8 +25,11 @@ do-build:
 	$(MAKE) -C $(_WRKSRC)/build
 do-install: $(PREFIX)/var/pkg/$(_NAME)
 $(PREFIX)/var/pkg/$(_NAME): | do-build
-	cd $(_WRKSRC)/build && \
-        tar cf - $(PROGRAMS) \
+	rm -rf $(STAGING)/$(_NAME)
+	mkdir -p $(STAGING)/$(_NAME)
+	$(MAKE) -C $(_WRKSRC)/build DEST_DIR=$(STAGING)/$(_NAME) install
+	cd $(STAGING)/$(_NAME) && \
+        tar cf - * \
         | tar xvf - -C $(PREFIX)/bin/ \
 	| awk '{print "bin/"$$1}' > $@
 do-clean:


### PR DESCRIPTION
To avoid maintaining file list outside of the daligner source.