### PR TITLE
lintr is not needed for deployment

### DIFF
--- a/ports/pacbio/pbcommandr/Makefile
+++ b/ports/pacbio/pbcommandr/Makefile
@@ -31,7 +31,6 @@ $(_WRKSRC)/install-pbbamr.R:
 	echo 'install.packages("logging",    repos="http://cran.r-project.org")' >> $(_WRKSRC)/install-pbbamr.R
 	echo 'install.packages("pryr",       repos="http://cran.r-project.org")' >> $(_WRKSRC)/install-pbbamr.R
 	echo 'install.packages("uuid",       repos="http://cran.r-project.org")' >> $(_WRKSRC)/install-pbbamr.R
-	echo 'install.packages("lintr",      repos="http://cran.r-project.org")' >> $(_WRKSRC)/install-pbbamr.R
 do-install: $(PREFIX)/var/pkg/$(_NAME)
 $(PREFIX)/var/pkg/$(_NAME): | do-fetch do-config
 	mkdir -p $(PREFIX)/lib/R/library


### PR DESCRIPTION
The static analyzer can't help once deployed and it greatly increases the install time.