### PR TITLE
VERBOSE output for backticks

### DIFF
--- a/bin/pitchfork
+++ b/bin/pitchfork
@@ -11,12 +11,19 @@ _ownpath  = os.path.abspath(__file__)
 _whereami = os.path.dirname(_ownpath)
 _projhome = os.path.dirname(_whereami)
 
+VERBOSE = os.environ.get('VERBOSE')
+try:
+    VERBOSE = int(VERBOSE)
+except Exception:
+    pass
 
 def backticks(cmd, merge_stderr=True):
     """
     Simulates the perl backticks (``) command with error-handling support
     Returns ( command output as sequence of strings, error code, error message )
     """
+    if VERBOSE:
+        print "`{}`".format(cmd)
     if merge_stderr:
         _stderr = subprocess.STDOUT
     else:


### PR DESCRIPTION
And 'checked' option.

Example:
```sh
$ export VERBOSE=1
$ make -j1 -C ports/python/virtualenv do-install
/opt/python-2.7.9/bin/python
make[1]: Entering directory `/home/UNIXHOME/cdunn/repo/gh/pitchfork/ports/python/virtualenv'
/home/UNIXHOME/cdunn/repo/gh/pitchfork/bin/pitchfork fetch --url https://pypi.python.org/packages/source/v/virtualenv/virtualenv-13.1.2.tar.gz
{'url': 'https://pypi.python.org/packages/source/v/virtualenv/virtualenv-13.1.2.tar.gz', 'subcommand': 'fetch'}
fetching https://pypi.python.org/packages/source/v/virtualenv/virtualenv-13.1.2.tar.gz
`curl -L -O https://pypi.python.org/packages/source/v/virtualenv/virtualenv-13.1.2.tar.gz`
```
```py
Traceback (most recent call last):
  File "/home/UNIXHOME/cdunn/repo/gh/pitchfork/bin/pitchfork", line 294, in <module>
    sys.exit(main())
  File "/home/UNIXHOME/cdunn/repo/gh/pitchfork/bin/pitchfork", line 287, in main
    pitchfork(pargs)
  File "/home/UNIXHOME/cdunn/repo/gh/pitchfork/bin/pitchfork", line 274, in pitchfork
    _out, _exit, _err = backticks('curl -L -O %s' % _url, checked=True)
  File "/home/UNIXHOME/cdunn/repo/gh/pitchfork/bin/pitchfork", line 56, in backticks
    errCode, cmd, errorMessage))
Exception: 77 <- `curl -L -O https://pypi.python.org/packages/source/v/virtualenv/virtualenv-13.1.2.tar.gz`
curl: (77) Problem with the SSL CA cert (path? access rights?)
make[1]: *** [virtualenv-13.1.2.tar.gz] Error 1
```