### PR TITLE
Fixed error during boost build process where /var/pkg/ is not created

### DIFF
--- a/ports/thirdparty/boost/Makefile
+++ b/ports/thirdparty/boost/Makefile
@@ -33,6 +33,7 @@ $(STAGING)/$(_NAME)/lib/libboost_system.a: | do-config
                 stage) >& build.log || $(PFHOME)/bin/diewith build.log
 do-install: $(PREFIX)/var/pkg/$(_NAME)
 $(PREFIX)/var/pkg/$(_NAME): | do-build
+	[ -e $$( dirname $@ ) ] || mkdir -p $$( dirname $@ )
 	mkdir -p $(STAGING)/$(_NAME)/include
 	cd $(_WRKSRC) && tar cf - boost | tar xf - -C $(STAGING)/$(_NAME)/include
 	cd $(STAGING)/$(_NAME) && tar cf - * | tar xf - -C $(PREFIX)
@@ -43,6 +44,7 @@ _NAME  = boost
 do-install:
 	ln -fsn $(_BOOST)/include/boost $(PREFIX)/include/
 	ln -fsn $(_BOOST)/lib/libboost* $(PREFIX)/lib/
+	[ -e $$( dirname $@ ) ] || mkdir -p $$( dirname $@ )
 	echo include/boost > $(PREFIX)/var/pkg/$(_NAME)
 	cd $(PREFIX) && find lib -name 'libbost*' >> $(PREFIX)/var/pkg/$(_NAME)
 endif

--- a/ports/thirdparty/boost/Makefile
+++ b/ports/thirdparty/boost/Makefile
@@ -44,7 +44,7 @@ _NAME  = boost
 do-install:
 	ln -fsn $(_BOOST)/include/boost $(PREFIX)/include/
 	ln -fsn $(_BOOST)/lib/libboost* $(PREFIX)/lib/
-	[ -e $$( dirname $@ ) ] || mkdir -p $$( dirname $@ )
+	[ -e $(PREFIX)/var/pkg ] || mkdir -p $(PREFIX)/var/pkg
 	echo include/boost > $(PREFIX)/var/pkg/$(_NAME)
 	cd $(PREFIX) && find lib -name 'libbost*' >> $(PREFIX)/var/pkg/$(_NAME)
 endif


### PR DESCRIPTION
Fixes the following error while building a new boost library.

```
mkdir -p /gpfs/flash/users/gzynda/pitchfork/staging/boost-1.60.0/include
cd /gpfs/flash/users/gzynda/pitchfork/workspace/boost-1.60.0 && tar cf - boost | tar xf - -C /gpfs/flash/users/gzynda/pitchfork/staging/boost-1.60.0/include                                                                                                        
cd /gpfs/flash/users/gzynda/pitchfork/staging/boost-1.60.0 && tar cf - * | tar xf - -C /gpfs/flash/users/gzynda/pitchfork/test_install                                                                                                                              
find /gpfs/flash/users/gzynda/pitchfork/staging/boost-1.60.0 ! -type d|awk -F '/gpfs/flash/users/gzynda/pitchfork/staging/boost-1.60.0/' '{print $2}' > /gpfs/flash/users/gzynda/pitchfork/test_install/var/pkg/boost-1.60.0                                        
/bin/bash: /gpfs/flash/users/gzynda/pitchfork/test_install/var/pkg/boost-1.60.0: No such file or directory                        
make[1]: *** [/gpfs/flash/users/gzynda/pitchfork/test_install/var/pkg/boost-1.60.0] Error 1                                       
make[1]: Leaving directory `/gpfs/flash/users/gzynda/pitchfork/ports/thirdparty/boost'                                            
make: *** [boost] Error 2
```